### PR TITLE
feat: Add second CFR search workflow with logical timers and availabi…

### DIFF
--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/01 - EN1b - Second CFR search (3-5km).bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/01 - EN1b - Second CFR search (3-5km).bru
@@ -1,5 +1,5 @@
 meta {
-  name: Create execution node - EN1
+  name: 01 - EN1b - Second CFR search (3-5km)
   type: http
   seq: 1
 }
@@ -18,17 +18,16 @@ headers {
 
 body:json {
   {
-    "Name": "EN1-Actions after reporter shares location",
-    "Description": "This execution node holds actions to find nearby CFRs and send notify them of the incident happened.",
+    "Name": "EN1b-Second CFR search (3-5 km)",
+    "Description": "Second, wider CFR search. Re-queries nearest-responders in the 3-5 km ring and overwrites CFR:Phonenumbers. Reached when the first 0-3 km attempt found no available CFR.",
     "Type": "ExecutionNode",
-    "ParentNodeId": "{{MAIN_YNN1_ID}}",
+    "ParentNodeId": "{{MAIN_CFR_AVAILABILITY_CHECK_ID}}",
     "SchemaId": "{{MAIN_SCHEMA_ID}}",
     "Actions": [
-    
       {
         "Type": "RestApiCall",
-        "Name": "Make REST API call to get nearest CFRs",
-        "Sequence": 2,
+        "Name": "Make REST API call to get nearest CFRs in 3-5 km ring",
+        "Sequence": 0,
         "Input": {
           "Params": [
             {
@@ -59,11 +58,11 @@ body:json {
                   },
                   {
                     "QueryParamKey": "minRadiusInKm",
-                    "QueryParamValue": 0
+                    "QueryParamValue": 3
                   },
                   {
                     "QueryParamKey": "maxRadiusInKm",
-                    "QueryParamValue": 3
+                    "QueryParamValue": 5
                   },
                   {
                     "QueryParamKey": "itemsPerPage",
@@ -100,29 +99,13 @@ script:post-response {
   let status = res.getStatus();
   console.log(status)
   if (status == 201) {
-    bru.setEnvVar("MAIN_EN1_ID", res.body.Data.id);
+    bru.setEnvVar("MAIN_EN1B_ID", res.body.Data.id);
   }
-  
 }
 
 tests {
   test("Request is successfull", function () {
       expect(res.getStatus()).to.equal(201);
-      var jsonRes = res.getBody();
-      expect(jsonRes.Status).to.eql('success');
+      expect(res.body.Status).to.eql('success');
   });
-  
-  test("Execution node is created", function () {
-      var jsonRes = res.getBody();
-      expect(jsonRes.Data).to.have.property('id');
-      expect(jsonRes.Data).to.have.property('Name');
-      expect(jsonRes.Data).to.have.property('Description');
-  });
-  
-}
-
-docs {
-  User login with username/phone/email and password.
-  
-  'LoginRoleId' is the role id through which user wants to log into the system provided the user has the role.
 }

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/02 - EN2b - Reporter msg & trigger children.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/02 - EN2b - Reporter msg & trigger children.bru
@@ -1,0 +1,99 @@
+meta {
+  name: 02 - EN2b - Reporter msg & trigger children
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{BASE_URL}}/engine/nodes
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+body:json {
+  {
+    "Name": "EN2b-Send message to reporter assuring help (attempt 2)",
+    "Description": "Attempt-2 mirror of EN2. Reassures the reporter and triggers a child CFR workflow for each phone in the 3-5 km ring.",
+    "Type": "ExecutionNode",
+    "ParentNodeId": "{{MAIN_EN1B_ID}}",
+    "SchemaId": "{{MAIN_SCHEMA_ID}}",
+    "Actions": [
+      {
+        "Type": "SendMessage",
+        "Name": "Send message - Assuring reporter CFR informed",
+        "Sequence": 0,
+        "Input": {
+          "Params": [
+            {
+              "Name": "Reporter Phone",
+              "Type": "Phone",
+              "Value": null,
+              "Source": "Almanac",
+              "Key": "ContextParams:Reporter:Phone"
+            },
+            {
+              "Name": "CFR notified message",
+              "Type": "Text",
+              "Value": "Nearby responders have been notified. In the mean time call 108 for ambulance assistance.Tell us what the issue is with the victim. We can help you with first aid tips. "
+            }
+          ]
+        }
+      },
+      {
+        "Type": "TriggerMultipleChildrenWorkflow",
+        "Name": "Trigger multiple workflows one for each CFR in the vicinity.",
+        "Sequence": 1,
+        "Input": {
+          "Params": [
+            {
+              "Name": "List of CFR phonenumbers",
+              "Type": "Array",
+              "Value": null,
+              "Source": "Almanac",
+              "Key": "ContextParams:CFR:Phonenumbers",
+              "SubType": "Phone"
+            },
+            {
+              "Name": "Schema Id",
+              "Type": "SchemaId",
+              "Value": "{{CHILD_SCHEMA_ID}}",
+              "Key": "SchemaId"
+            }
+          ]
+        },
+        "Output": {
+          "Params": [
+            {
+              "Name": "CFR Phone",
+              "Type": "Phone",
+              "Value": null,
+              "Destination": "Almanac",
+              "Key": "ContextParams:CFR:Phone"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+script:post-response {
+  let status = res.getStatus();
+  console.log(status)
+  if (status == 201) {
+    bru.setEnvVar("MAIN_EN2B_ID", res.body.Data.id);
+  }
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(201);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/03 - EN2b_P1 - 30s message.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/03 - EN2b_P1 - 30s message.bru
@@ -1,0 +1,65 @@
+meta {
+  name: 03 - EN2b_P1 - 30s message
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{BASE_URL}}/engine/nodes
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+body:json {
+  {
+    "Name": "EN2b-Send message to reporter assuring help (attempt 2 - 30s)",
+    "Description": "Attempt-2 mirror of the 30s escalation message.",
+    "Type": "ExecutionNode",
+    "ParentNodeId": "{{MAIN_EN2B_ID}}",
+    "SchemaId": "{{MAIN_SCHEMA_ID}}",
+    "Actions": [
+      {
+        "Type": "SendMessage",
+        "Name": "Send message - Assuring reporter - first message",
+        "Sequence": 0,
+        "Input": {
+          "Params": [
+            {
+              "Name": "Reporter Phone",
+              "Type": "Phone",
+              "Value": null,
+              "Source": "Almanac",
+              "Key": "ContextParams:Reporter:Phone"
+            },
+            {
+              "Name": "CFR notified message",
+              "Type": "Text",
+              "Value": " Please hang in there, we are looking out for responders"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+script:post-response {
+  let status = res.getStatus();
+  console.log(status)
+  if (status == 201) {
+    bru.setEnvVar("MAIN_EN2B_ID_P1", res.body.Data.id);
+  }
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(201);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/04 - EN2b_P2 - 60s message.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/04 - EN2b_P2 - 60s message.bru
@@ -1,0 +1,65 @@
+meta {
+  name: 04 - EN2b_P2 - 60s message
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{BASE_URL}}/engine/nodes
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+body:json {
+  {
+    "Name": "EN2b-Send message to reporter assuring help (attempt 2 - 60s)",
+    "Description": "Attempt-2 mirror of the 60s escalation message.",
+    "Type": "ExecutionNode",
+    "ParentNodeId": "{{MAIN_EN2B_ID}}",
+    "SchemaId": "{{MAIN_SCHEMA_ID}}",
+    "Actions": [
+      {
+        "Type": "SendMessage",
+        "Name": "Send message - Assuring reporter - second message",
+        "Sequence": 0,
+        "Input": {
+          "Params": [
+            {
+              "Name": "Reporter Phone",
+              "Type": "Phone",
+              "Value": null,
+              "Source": "Almanac",
+              "Key": "ContextParams:Reporter:Phone"
+            },
+            {
+              "Name": "CFR notified message",
+              "Type": "Text",
+              "Value": " Please hang in there, we are looking out for responders"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+script:post-response {
+  let status = res.getStatus();
+  console.log(status)
+  if (status == 201) {
+    bru.setEnvVar("MAIN_EN2B_ID_P2", res.body.Data.id);
+  }
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(201);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/05 - EN2b_P3 - 90s message (no TN1_R trigger).bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/05 - EN2b_P3 - 90s message (no TN1_R trigger).bru
@@ -1,0 +1,65 @@
+meta {
+  name: 05 - EN2b_P3 - 90s message (no TN1_R trigger)
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{BASE_URL}}/engine/nodes
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+body:json {
+  {
+    "Name": "EN2b-Send message to reporter assuring help (attempt 2 - 90s)",
+    "Description": "Attempt-2 mirror of the 90s escalation message. Deliberately does NOT re-trigger TN1_R (the reporter-resolution question already ran in attempt 1 and its nodes are shared/single-use).",
+    "Type": "ExecutionNode",
+    "ParentNodeId": "{{MAIN_EN2B_ID}}",
+    "SchemaId": "{{MAIN_SCHEMA_ID}}",
+    "Actions": [
+      {
+        "Type": "SendMessage",
+        "Name": "Send message - Assuring reporter - third message",
+        "Sequence": 0,
+        "Input": {
+          "Params": [
+            {
+              "Name": "Reporter Phone",
+              "Type": "Phone",
+              "Value": null,
+              "Source": "Almanac",
+              "Key": "ContextParams:Reporter:Phone"
+            },
+            {
+              "Name": "CFR notified message",
+              "Type": "Text",
+              "Value": "All our responders are certified volunteers. Please hang in there, we have not given up yet."
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+script:post-response {
+  let status = res.getStatus();
+  console.log(status)
+  if (status == 201) {
+    bru.setEnvVar("MAIN_EN2B_ID_P3", res.body.Data.id);
+  }
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(201);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/06 - LTN2b - 30s timer.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/06 - LTN2b - 30s timer.bru
@@ -1,0 +1,47 @@
+meta {
+  name: 06 - LTN2b - 30s timer
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{BASE_URL}}/engine/nodes/logical-timer-node
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+body:json {
+  {
+    "Name": "T1b-CFR Yes Response Checking Timer (attempt 2 - 30s)",
+    "Description": "Attempt-2 30s poll: checks whether any CFR has responded YES (CFR:Responders not empty). Reuses T1_RULE via RuleId.",
+    "Type": "LogicalTimerNode",
+    "ParentNodeId": "{{MAIN_EN2B_ID}}",
+    "SchemaId": "{{MAIN_SCHEMA_ID}}",
+    "RuleId": "{{T1_RULE_ID}}",
+    "NumberOfTries": 1,
+    "DelaySeconds": 30,
+    "NextNodeIdOnSuccess": null,
+    "NextNodeIdOnTimeout": null
+  }
+}
+
+script:post-response {
+  let status = res.getStatus();
+  console.log(status)
+  if (status == 201) {
+    bru.setEnvVar("MAIN_LTN2B_ID", res.body.Data.id);
+  }
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(201);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/07 - LTN2b_P1 - 60s timer.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/07 - LTN2b_P1 - 60s timer.bru
@@ -1,0 +1,47 @@
+meta {
+  name: 07 - LTN2b_P1 - 60s timer
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{BASE_URL}}/engine/nodes/logical-timer-node
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+body:json {
+  {
+    "Name": "T1b-CFR Yes Response Checking Timer (attempt 2 - 60s)",
+    "Description": "Attempt-2 second 30s poll (60s cumulative). Reuses T1_RULE via RuleId.",
+    "Type": "LogicalTimerNode",
+    "ParentNodeId": "{{MAIN_EN2B_ID_P1}}",
+    "SchemaId": "{{MAIN_SCHEMA_ID}}",
+    "RuleId": "{{T1_RULE_ID}}",
+    "NumberOfTries": 1,
+    "DelaySeconds": 30,
+    "NextNodeIdOnSuccess": null,
+    "NextNodeIdOnTimeout": null
+  }
+}
+
+script:post-response {
+  let status = res.getStatus();
+  console.log(status)
+  if (status == 201) {
+    bru.setEnvVar("MAIN_LTN2B_ID_P1", res.body.Data.id);
+  }
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(201);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/08 - LTN2b_P2 - 90s timer.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/08 - LTN2b_P2 - 90s timer.bru
@@ -1,0 +1,47 @@
+meta {
+  name: 08 - LTN2b_P2 - 90s timer
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{BASE_URL}}/engine/nodes/logical-timer-node
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+body:json {
+  {
+    "Name": "T1b-CFR Yes Response Checking Timer (attempt 2 - 90s)",
+    "Description": "Attempt-2 third 30s poll (90s cumulative). Reuses T1_RULE via RuleId.",
+    "Type": "LogicalTimerNode",
+    "ParentNodeId": "{{MAIN_EN2B_ID_P2}}",
+    "SchemaId": "{{MAIN_SCHEMA_ID}}",
+    "RuleId": "{{T1_RULE_ID}}",
+    "NumberOfTries": 1,
+    "DelaySeconds": 30,
+    "NextNodeIdOnSuccess": null,
+    "NextNodeIdOnTimeout": null
+  }
+}
+
+script:post-response {
+  let status = res.getStatus();
+  console.log(status)
+  if (status == 201) {
+    bru.setEnvVar("MAIN_LTN2B_ID_P2", res.body.Data.id);
+  }
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(201);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/09 - LTN2b_P3 - 120s timer.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/09 - LTN2b_P3 - 120s timer.bru
@@ -1,0 +1,47 @@
+meta {
+  name: 09 - LTN2b_P3 - 120s timer
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{BASE_URL}}/engine/nodes/logical-timer-node
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+body:json {
+  {
+    "Name": "T1b-CFR Yes Response Checking Timer (attempt 2 - 120s)",
+    "Description": "Attempt-2 fourth/final 30s poll (120s cumulative). On timeout (still no available CFR) the flow goes to the ambulance fallback. Reuses T1_RULE via RuleId.",
+    "Type": "LogicalTimerNode",
+    "ParentNodeId": "{{MAIN_EN2B_ID_P3}}",
+    "SchemaId": "{{MAIN_SCHEMA_ID}}",
+    "RuleId": "{{T1_RULE_ID}}",
+    "NumberOfTries": 1,
+    "DelaySeconds": 30,
+    "NextNodeIdOnSuccess": null,
+    "NextNodeIdOnTimeout": null
+  }
+}
+
+script:post-response {
+  let status = res.getStatus();
+  console.log(status)
+  if (status == 201) {
+    bru.setEnvVar("MAIN_LTN2B_ID_P3", res.body.Data.id);
+  }
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(201);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/10 - YN2b - Availability check 2 node.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/10 - YN2b - Availability check 2 node.bru
@@ -1,0 +1,63 @@
+meta {
+  name: 10 - YN2b - Availability check 2 node
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{BASE_URL}}/engine/nodes/logical-yes-no-action-node
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+body:json {
+  {
+    "Name": "Decision (Yes/No) node for CFR availability check (attempt 2)",
+    "Description": "Attempt-2 mirror of the availability check. If the 3-5 km CFR array is empty, Yes-action routes to the ambulance fallback (NOCFR_EN_ID); otherwise Continue to EN2b.",
+    "Type": "LogicalYesNoActionNode",
+    "ParentNodeId": "{{MAIN_EN1B_ID}}",
+    "SchemaId": "{{MAIN_SCHEMA_ID}}",
+    "YesAction": {
+      "Type": "SetNextNode",
+      "Name": "Send no CFR available message",
+      "IsPathAction": true,
+      "Input": {
+        "Params": [
+          {
+            "Name": "ENend-Get nearby ambulances",
+            "Type": "NodeId",
+            "Value": "{{NOCFR_EN_ID}}"
+          }
+        ]
+      }
+    },
+    "NoAction": {
+      "Type": "Continue",
+      "Name": "Continue to next node.",
+      "IsPathAction": true,
+      "Description": "This will set the next node as current node.",
+      "Input": null
+    }
+  }
+}
+
+script:post-response {
+  let status = res.getStatus();
+  console.log(status)
+  if (status == 201) {
+    bru.setEnvVar("MAIN_CFR_AVAILABILITY_CHECK_2_ID", res.body.Data.id);
+  }
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(201);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/11 - YN2b - Availability check 2 rule.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/11 - YN2b - Availability check 2 rule.bru
@@ -1,0 +1,41 @@
+meta {
+  name: 11 - YN2b - Availability check 2 rule
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{BASE_URL}}/engine/rules
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+body:json {
+  {
+    "Name": "CFR availability check rule (attempt 2)",
+    "Description": "This rule checks if the 3-5 km CFR Phonenumbers array contains any entries",
+    "ParentNodeId": "{{MAIN_CFR_AVAILABILITY_CHECK_2_ID}}",
+    "SchemaId": "{{MAIN_SCHEMA_ID}}"
+  }
+}
+
+script:post-response {
+  let status = res.getStatus();
+  console.log(status)
+  if (status == 201) {
+    bru.setEnvVar("CFR_AVAILABILITY_CHECK_2_RULE_ID", res.body.Data.id);
+  }
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(201);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/12 - YN2b - Availability check 2 condition.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/12 - YN2b - Availability check 2 condition.bru
@@ -1,0 +1,50 @@
+meta {
+  name: 12 - YN2b - Availability check 2 condition
+  type: http
+  seq: 12
+}
+
+post {
+  url: {{BASE_URL}}/engine/conditions
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+body:json {
+  {
+    "Name": "Base condition for CFR availability check (attempt 2)",
+    "Description": "This condition checks if the 3-5 km CFR Phonenumbers array is empty",
+    "ParentRuleId": "{{CFR_AVAILABILITY_CHECK_2_RULE_ID}}",
+    "ParentConditionId": null,
+    "OperatorType": "Logical",
+    "LogicalOperatorType": "IsEmpty",
+    "FirstOperand": {
+      "DataType": "Array",
+      "Name": "CFR Phonenumbers list",
+      "Value": null,
+      "Source": "Almanac",
+      "Key": "ContextParams:CFR:Phonenumbers"
+    }
+  }
+}
+
+script:post-response {
+  let status = res.getStatus();
+  console.log(status)
+  if (status == 201) {
+    bru.setEnvVar("CFR_AVAILABILITY_CHECK_2_BASE_CONDITION_ID", res.body.Data.id);
+  }
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(201);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/13 - Set condition to availability check 2 rule.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/13 - Set condition to availability check 2 rule.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 13 - Set condition to availability check 2 rule
+  type: http
+  seq: 13
+}
+
+put {
+  url: {{BASE_URL}}/engine/rules/{{CFR_AVAILABILITY_CHECK_2_RULE_ID}}/base-condition/{{CFR_AVAILABILITY_CHECK_2_BASE_CONDITION_ID}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/14 - Set rule to availability check 2 node.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/14 - Set rule to availability check 2 node.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 14 - Set rule to availability check 2 node
+  type: http
+  seq: 14
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_CFR_AVAILABILITY_CHECK_2_ID}}/base-rule/{{CFR_AVAILABILITY_CHECK_2_RULE_ID}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/15 - Link EN1b to YN2b.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/15 - Link EN1b to YN2b.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 15 - Link EN1b to YN2b
+  type: http
+  seq: 15
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_EN1B_ID}}/next-node/{{MAIN_CFR_AVAILABILITY_CHECK_2_ID}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/16 - Link YN2b to EN2b (continue path).bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/16 - Link YN2b to EN2b (continue path).bru
@@ -1,0 +1,24 @@
+meta {
+  name: 16 - Link YN2b to EN2b (continue path)
+  type: http
+  seq: 16
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_CFR_AVAILABILITY_CHECK_2_ID}}/next-node/{{MAIN_EN2B_ID}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/17 - Link EN2b to LTN2b.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/17 - Link EN2b to LTN2b.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 17 - Link EN2b to LTN2b
+  type: http
+  seq: 17
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_EN2B_ID}}/next-node/{{MAIN_LTN2B_ID}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/18 - LTN2b success to EN4.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/18 - LTN2b success to EN4.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 18 - LTN2b success to EN4
+  type: http
+  seq: 18
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_LTN2B_ID}}/next-node-on-timer-success/{{MAIN_EN4_ID}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/19 - LTN2b timeout to EN2b_P1.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/19 - LTN2b timeout to EN2b_P1.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 19 - LTN2b timeout to EN2b_P1
+  type: http
+  seq: 19
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_LTN2B_ID}}/next-node-on-timer-timeout/{{MAIN_EN2B_ID_P1}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/20 - Link EN2b_P1 to LTN2b_P1.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/20 - Link EN2b_P1 to LTN2b_P1.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 20 - Link EN2b_P1 to LTN2b_P1
+  type: http
+  seq: 20
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_EN2B_ID_P1}}/next-node/{{MAIN_LTN2B_ID_P1}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/21 - LTN2b_P1 success to EN4.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/21 - LTN2b_P1 success to EN4.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 21 - LTN2b_P1 success to EN4
+  type: http
+  seq: 21
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_LTN2B_ID_P1}}/next-node-on-timer-success/{{MAIN_EN4_ID}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/22 - LTN2b_P1 timeout to EN2b_P2.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/22 - LTN2b_P1 timeout to EN2b_P2.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 22 - LTN2b_P1 timeout to EN2b_P2
+  type: http
+  seq: 22
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_LTN2B_ID_P1}}/next-node-on-timer-timeout/{{MAIN_EN2B_ID_P2}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/23 - Link EN2b_P2 to LTN2b_P2.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/23 - Link EN2b_P2 to LTN2b_P2.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 23 - Link EN2b_P2 to LTN2b_P2
+  type: http
+  seq: 23
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_EN2B_ID_P2}}/next-node/{{MAIN_LTN2B_ID_P2}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/24 - LTN2b_P2 success to EN4.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/24 - LTN2b_P2 success to EN4.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 24 - LTN2b_P2 success to EN4
+  type: http
+  seq: 24
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_LTN2B_ID_P2}}/next-node-on-timer-success/{{MAIN_EN4_ID}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/25 - LTN2b_P2 timeout to EN2b_P3.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/25 - LTN2b_P2 timeout to EN2b_P3.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 25 - LTN2b_P2 timeout to EN2b_P3
+  type: http
+  seq: 25
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_LTN2B_ID_P2}}/next-node-on-timer-timeout/{{MAIN_EN2B_ID_P3}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/26 - Link EN2b_P3 to LTN2b_P3.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/26 - Link EN2b_P3 to LTN2b_P3.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 26 - Link EN2b_P3 to LTN2b_P3
+  type: http
+  seq: 26
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_EN2B_ID_P3}}/next-node/{{MAIN_LTN2B_ID_P3}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/27 - LTN2b_P3 success to EN4.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/27 - LTN2b_P3 success to EN4.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 27 - LTN2b_P3 success to EN4
+  type: http
+  seq: 27
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_LTN2B_ID_P3}}/next-node-on-timer-success/{{MAIN_EN4_ID}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/28 - LTN2b_P3 timeout to EN5 (ambulance).bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/28 - LTN2b_P3 timeout to EN5 (ambulance).bru
@@ -1,0 +1,24 @@
+meta {
+  name: 28 - LTN2b_P3 timeout to EN5 (ambulance)
+  type: http
+  seq: 28
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_LTN2B_ID_P3}}/next-node-on-timer-timeout/{{MAIN_EN5_ID}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/folder.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/A - Reporter workflow/20 - Second CFR search (3-5 km)/folder.bru
@@ -1,0 +1,26 @@
+meta {
+  name: 20 - Second CFR search (3-5 km)
+  seq: 20
+}
+
+docs {
+  Second (wider) CFR search attempt.
+
+  Triggered when the first 0-3 km attempt fails to yield an available CFR:
+    (a) first search returns an empty CFR list, OR
+    (b) CFRs were found but none replied "Available" within the 30/60/90/120s window.
+
+  This section mirrors the attempt-1 "notify + poll" subgraph for a 3-5 km ring:
+    EN1b (search 3-5km) -> YN2b (IsEmpty check) -> EN2b (notify + trigger children)
+      -> LTN2b 30/60/90/120s polling on CFR:Responders
+         - every timer SUCCESS -> reuse EN4 -> EN6 -> EN7 (existing primary path)
+         - final 120s TIMEOUT  -> reuse EN5 (ambulance fallback) -> terminator
+         - YN2b empty          -> reuse NOCFR_EN_ID (ambulance fallback)
+
+  EN2b_P3 (90s) deliberately does NOT re-trigger TN1_R: the reporter-resolution
+  question (QN1_R) already ran during attempt 1 and its nodes are shared/single-use.
+
+  This section only CREATES and internally wires the attempt-2 nodes. The two
+  requests that re-route attempt-1's failure exits (empty list, 120s timeout) into
+  EN1b live in the sibling "Patch" folder, which runs last in a recursive build.
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/Patch/01 - Reroute - Get attempt-1 availability check (yes-action id).bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/Patch/01 - Reroute - Get attempt-1 availability check (yes-action id).bru
@@ -1,0 +1,34 @@
+meta {
+  name: 01 - Reroute - Get attempt-1 availability check (yes-action id)
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_CFR_AVAILABILITY_CHECK_ID}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+script:post-response {
+  let status = res.getStatus();
+  console.log(status)
+  if (status == 200) {
+    // Capture the YesAction (empty-path / IsEmpty=true) node-action id so we can
+    // re-point it from the ambulance node (NOCFR_EN_ID) to the second search (EN1b).
+    bru.setEnvVar("YN1_YES_ACTION_ID", res.body.Data.YesAction.id);
+  }
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Data).to.have.property('YesAction');
+  });
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/Patch/02 - Reroute - Empty path to EN1b (was ambulance).bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/Patch/02 - Reroute - Empty path to EN1b (was ambulance).bru
@@ -1,0 +1,50 @@
+meta {
+  name: 02 - Reroute - Empty path to EN1b (was ambulance)
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{BASE_URL}}/engine/node-actions/{{YN1_YES_ACTION_ID}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+body:json {
+  {
+    "Input": {
+      "Params": [
+        {
+          "Name": "Second CFR search (3-5 km)",
+          "Type": "NodeId",
+          "Value": "{{MAIN_EN1B_ID}}"
+        }
+      ]
+    }
+  }
+}
+
+script:post-response {
+  let status = res.getStatus();
+  console.log(status)
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}
+
+docs {
+  Re-points attempt-1's availability-check "empty" branch (YesAction SetNextNode)
+  from the ambulance node (NOCFR_EN_ID) to the second, wider search (EN1b).
+  Only the Input is updated; the action Type (SetNextNode) is preserved because the
+  node-action update only writes non-null fields.
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/Patch/03 - Reroute - Attempt-1 120s timeout to EN1b (was ambulance).bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/Patch/03 - Reroute - Attempt-1 120s timeout to EN1b (was ambulance).bru
@@ -1,0 +1,31 @@
+meta {
+  name: 03 - Reroute - Attempt-1 120s timeout to EN1b (was ambulance)
+  type: http
+  seq: 3
+}
+
+put {
+  url: {{BASE_URL}}/engine/nodes/{{MAIN_LTN2_ID_P3}}/next-node-on-timer-timeout/{{MAIN_EN1B_ID}}
+  body: none
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-api-key: {{API_KEY}}
+  Authorization: Bearer {{MODERATOR_USER_JWT}}
+}
+
+tests {
+  test("Request is successfull", function () {
+      expect(res.getStatus()).to.equal(200);
+      expect(res.body.Status).to.eql('success');
+  });
+}
+
+docs {
+  Re-points attempt-1's final (120s) poll timeout from the ambulance node (EN5 /
+  MAIN_EN5_ID) to the second, wider search (EN1b). After this, EN5 is only reached
+  from attempt-2's own 120s timeout - i.e. ambulance fallback happens only after
+  BOTH the 0-3 km and 3-5 km attempts fail.
+}

--- a/bruno/Workflow service/01 - Construction/ALERT/Patch/folder.bru
+++ b/bruno/Workflow service/01 - Construction/ALERT/Patch/folder.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Patch
+}
+
+docs {
+  Update / patch requests (NOT fresh node creation).
+
+  These requests modify wiring on nodes that were already created by the regular
+  seed collection ("A - Reporter workflow" / "B - CFR Workflow"). They live in this
+  sub-folder so the seed folders stay purely additive / from-scratch.
+
+  Ordering: this folder sits inside ALERT and sorts last ("Patch" > "A..." / "B..."),
+  so a recursive run of the ALERT folder builds the seed first and then applies these
+  patches on top - i.e. running ALERT recursively produces a COMPLETE build. The
+  requests reference ids produced by the seed (e.g. MAIN_EN1B_ID,
+  MAIN_CFR_AVAILABILITY_CHECK_ID, MAIN_LTN2_ID_P3), so they must run after it.
+
+  Current patches:
+    - Re-route attempt-1's two failure exits (empty CFR list, and the 120s
+      no-response timeout) from the ambulance fallback into the second, wider
+      CFR search (EN1b) added in "20 - Second CFR search (3-5 km)".
+}


### PR DESCRIPTION
…lity checks

- Implemented a series of logical timer nodes (30s, 60s, 90s, 120s) for checking CFR responses in the 3-5 km range.
- Created availability check nodes and rules to determine if CFRs are available.
- Established conditions to check if the CFR phone numbers array is empty.
- Linked nodes to manage the flow based on timer success and timeouts, including fallback to ambulance if no CFRs are available.
- Added patch requests to reroute existing nodes from the first attempt to the new second CFR search workflow.
- Documented the purpose and flow of the new nodes and patches for clarity and future reference.